### PR TITLE
Fixing bug with Time.to_s

### DIFF
--- a/lib/solareventcalculator.rb
+++ b/lib/solareventcalculator.rb
@@ -118,7 +118,7 @@ class SolarEventCalculator
     sunLocalHour = compute_local_hour_angle(cosineSunLocalHour, isSunrise)
     localMeanTime = compute_local_mean_time(sunTrueLong, longHour, eventLongHour, sunLocalHour)
 
-    timeParts = localMeanTime.to_s('F').split('.')
+    timeParts = localMeanTime.to_f.to_s.split('.')
     mins = BigDecimal.new("." + timeParts[1]) * BigDecimal.new("60")
     mins = mins.truncate()
     mins = pad_minutes(mins.to_i)

--- a/rubysunrise.gemspec
+++ b/rubysunrise.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do | s |
   s.name = "RubySunrise"
-  s.version = "0.3"
+  s.version = "0.3.1"
   s.author = "Mike Reedell / LuckyCatLabs"
   s.email = "mike@reedell.com"
   s.homepage = "http://www.mikereedell.com"


### PR DESCRIPTION
Some versions of Ruby don't like Time.to_s('F') and will throw an exception. This pull request replaces the aforementioned call with Time.to_f.to_s which is more reliable across all versions of Ruby.

There are no other instances of "Time.to_s(" that I could find.
