### PR TITLE
Fix comparison of DateTime value with nil

### DIFF
--- a/lib/solareventcalculator.rb
+++ b/lib/solareventcalculator.rb
@@ -160,7 +160,8 @@ class SolarEventCalculator
   end
 
   def convert_to_datetime(time)
-    DateTime.parse("#{@date.strftime}T#{time.hour}:#{time.min}:00+0000") unless time == nil
+    return unless time
+    DateTime.parse("#{@date.strftime}T#{time.hour}:#{time.min}:00+0000")
   end
 
   def compute_civil_sunrise(timezone)


### PR DESCRIPTION
Comparison of a Time or DateTime value with nil raises an error: 

```
2.3.1 :004 > DateTime.now == nil
NoMethodError: undefined method `to_datetime' for nil:NilClass
```

I simply turned this into a guard clause (writing it like `nil == time` would have worked, too).